### PR TITLE
daemon respawns if shut down by NSO

### DIFF
--- a/src/erlang-lib/ec_genet/src/ec_genet.app.src
+++ b/src/erlang-lib/ec_genet/src/ec_genet.app.src
@@ -6,7 +6,7 @@
   {vsn, "%VSN%"},
   {modules, [%MODULES%]},
   {mod, {ec_genet, []}},
-  {registered, [ec_genet_server, ec_genet_logger, ec_genet_logconf]},
+  {registered, [ec_genet_owner, ec_genet_server, ec_genet_logger, ec_genet_logconf]},
   {applications, [stdlib, kernel]},
   {env, [{ncs_restart_type,permanent}]}
  ]}.

--- a/src/erlang-lib/ec_genet/src/ec_genet_owner.erl
+++ b/src/erlang-lib/ec_genet/src/ec_genet_owner.erl
@@ -1,0 +1,67 @@
+-module(ec_genet_owner).
+
+-behaviour(gen_server).
+
+-export([start_link/0]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-include_lib("econfd/include/econfd.hrl").
+
+
+-define(SERVER, ?MODULE).
+
+-record(state, {}).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+init([]) ->
+    process_flag(trap_exit, true), % Triggers call to terminate/2
+    ets:new(ec_genet_maps, [ordered_set, public, named_table, {read_concurrency,true}]),
+    log(info, "Owner started", []),
+    {ok, #state{}}.
+
+%%--------------------------------------------------------------------
+handle_call(Req, _From, State) ->
+    log(error, "Got unexpected call: ~p", [Req]),
+    Reply = error,
+    {reply, Reply, State}.
+
+%%--------------------------------------------------------------------
+handle_cast(Msg, State) ->
+    log(error, "Got unexpected cast: ~p", [Msg]),
+    {noreply, State}.
+
+%%--------------------------------------------------------------------
+handle_info(Info, State) ->
+    log(error, "Got unexpected info: ~p", [Info]),
+    {noreply, State}.
+
+%%--------------------------------------------------------------------
+terminate(Reason, _State) ->
+    log(info, "Server stopped - ~p", [Reason]),
+    ok.
+
+%%--------------------------------------------------------------------
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+log(error, Format, Args) ->
+    econfd:log(?CONFD_LEVEL_ERROR, "~p: " ++ Format, [?SERVER | Args]);
+log(info, Format, Args) ->
+    econfd:log(?CONFD_LEVEL_INFO,  "~p: " ++ Format, [?SERVER | Args]);
+log(trace, Format, Args) ->
+    econfd:log(?CONFD_LEVEL_TRACE, "~p: " ++ Format, [?SERVER | Args]).

--- a/src/erlang-lib/ec_genet/src/ec_genet_server.erl
+++ b/src/erlang-lib/ec_genet/src/ec_genet_server.erl
@@ -53,7 +53,6 @@ init([]) ->
     ok = econfd:register_trans_cb(Daemon, TransDP),
     ok = econfd:register_data_cb(Daemon, DP),
     ok = econfd:register_done(Daemon),
-    ets:new(ec_genet_maps, [ordered_set, public, named_table, {read_concurrency,true}]),
     log(info, "Server started", []),
     {ok, #state{}}.
 
@@ -72,6 +71,9 @@ handle_cast(Msg, State) ->
     {noreply, State}.
 
 %%--------------------------------------------------------------------
+handle_info({'EXIT',_,shutdown}, State) ->
+    log(error, "Received process shutdown info; stopping daemon", []),
+    {stop, shutdown, State};
 handle_info(Info, State) ->
     log(error, "Got unexpected info: ~p", [Info]),
     {noreply, State}.

--- a/src/erlang-lib/ec_genet/src/ec_genet_sup.erl
+++ b/src/erlang-lib/ec_genet/src/ec_genet_sup.erl
@@ -33,13 +33,15 @@ init([]) ->
     Shutdown = 2000,
     Type = worker,
 
+    GenetOwner = {ec_genet_owner, {ec_genet_owner, start_link, []},
+                  Restart, Shutdown, Type, [ec_genet_owner]},
     GenetChild = {ec_genet_server, {ec_genet_server, start_link, []},
                   Restart, Shutdown, Type, [ec_genet_server]},
     LoggerChild = {ec_genet_logger, {ec_genet_logger, start_link, []},
                   Restart, Shutdown, Type, [ec_genet_logger]},
     LogConfSubChild = {ec_genet_logconf, {ec_genet_subscriber, start_link, []},
                   Restart, Shutdown, Type, [ec_genet_subscriber]},
-    {ok, {SupFlags, [GenetChild, LoggerChild, LogConfSubChild]}}.
+    {ok, {SupFlags, [GenetOwner, GenetChild, LoggerChild, LogConfSubChild]}}.
 
 %%%===================================================================
 %%% Internal functions


### PR DESCRIPTION
This commit introduces two changes:

* ownership of the ets table is separated from the daemon handler
* the daemon handler stops itself when it receives `{'EXIT',_Pid,shutdown}` info

As a result, when NSO shuts down the worker, daemon handler stops and is restarted by the supervisor; the ets table is kept intact and all registered mappings stay valid.

An unfortunate consequence is that the daemon handler becomes effectively immortal and cannot be replaced by e.g. external daemon; this will be dealt with elsewhere (if at all...).