### PR TITLE
restart the subscriber if the subscription reader terminates

### DIFF
--- a/src/erlang-lib/ec_genet/src/ec_genet_subscriber.erl
+++ b/src/erlang-lib/ec_genet/src/ec_genet_subscriber.erl
@@ -42,6 +42,9 @@ handle_cast(Msg, State) ->
     {noreply, State}.
 
 %%--------------------------------------------------------------------
+handle_info({'EXIT',_,_}, State) ->
+    eclog(error, "Received process exit info; stopping subscriber", []),
+    {stop, shutdown, State};
 handle_info(Info, State) ->
     eclog(error, "Got unexpected info: ~p", [Info]),
     {noreply, State}.


### PR DESCRIPTION
This is very similar to the change implemented recently for `genet_server`: `genet_subscriber` starts a new process to handle subscription changes and links it to itself, but it does not react when the process terminates. As a result, if the reader process terminates for whatever reason, any genet logging configuration changes will cause NSO to wait forever (with `/ncs-config/cdb/client-timeout` set to infinity, the default).

This change makes whole subscriber shut down so that it is restarted by the supervisor.