### PR TITLE
Cannot assume that we will get path with emptied keys.

### DIFF
--- a/src/erlang-lib/ec_genet/src/ec_genet_server.erl
+++ b/src/erlang-lib/ec_genet/src/ec_genet_server.erl
@@ -778,10 +778,16 @@ extract_keys(Path) ->
 inject_keys(Path, KeySet) ->
     {InjectedPath, []} = lists:mapfoldl(fun inject_keys_int/2, KeySet, Path),
     InjectedPath.
-inject_keys_int({}, [FirstKey|RemainingKeySet]) ->
-    {FirstKey, RemainingKeySet};
 inject_keys_int(E, KeySet) ->
-    {E, KeySet}.
+    IsTuple = is_tuple(E),
+    if
+    (IsTuple == true) ->
+        %% Replace key with new key.
+        [FirstKey|RemainingKeySet] = KeySet,
+        {FirstKey, RemainingKeySet};
+    true ->
+        {E, KeySet}
+    end.
 
 tctx_maapi_sock(Tctx) ->
     Tctx#confd_trans_ctx.opaque.


### PR DESCRIPTION
Code assumes that user empties the keys in the PATH variable. 
While writing generic code, it is difficult to empty keys. 
And, fdn_keys/fup_keys is not called for keys that are emptied. They are called for all keys. 
Hence modified the code to replace keys even when they are not empty.